### PR TITLE
Little bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,14 @@ New in Version 3.0 - the Quest API is now publicly available for use! See the in
 
 Some challenges simply don't work in this context. Any challenge that doesn't work will be 'locked' and you won't be able to select it.
 
-If you've created a new custom challenge and you want it to be compatible with this mod, you need to set a flag named "P03" on the challenge using the Challenge Manager in API 2.4+
+If you've created a new custom challenge and you want it to be compatible with this mod, you need to set a flag named "P03" on the challenge using the Challenge Manager in API 2.4+. 
+You can also set a flag called "noleshy" to prevent your challenge from showing up in a leshy run.
 
 
 ```c#
 ChallengeManager.FullChallenge fch = ChallengeManager.AddSpecific(...)
-fch.SetFlags("P03");
+fch.SetFlags("P03"); // Allows the challenge to appear in a P03 run
+fch.SetFlags("noleshy"); // Keeps the challenge from appearing in a leshy run
 ```
 
 If the challenge does not have this flag set, it will always be locked when the player is setting up a P03 run.

--- a/cards/CustomCards.cs
+++ b/cards/CustomCards.cs
@@ -563,7 +563,7 @@ namespace Infiniscryption.P03KayceeRun.Patchers
                         ab.Info.powerLevel += 2;
 
                     if (ab.Id == Ability.ActivatedRandomPowerEnergy && P03AscensionSaveData.IsP03Run)
-                        ab.Info.rulebookDescription = ab.Info.rulebookDescription.Replace("1 Energy", "3 Energy");
+                        ab.Info.rulebookDescription = ab.Info.rulebookDescription.Replace("1", "3");
 
                     if (ab.Id == Ability.DrawCopy && P03AscensionSaveData.IsP03Run)
                         ab.Info.canStack = true;

--- a/cards/Necromancer.cs
+++ b/cards/Necromancer.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using DiskCardGame;
+using Infiniscryption.P03KayceeRun.Patchers;
 using InscryptionAPI.Card;
 using InscryptionAPI.Helpers;
 using UnityEngine;
@@ -33,7 +34,7 @@ namespace Infiniscryption.P03KayceeRun.Cards
 
         public override bool RespondsToOtherCardDie(PlayableCard card, CardSlot deathSlot, bool fromCombat, PlayableCard killer)
         {
-            return this.Card.OnBoard && card.OpponentCard == this.Card.OpponentCard && !card.HasAbility(Ability.Brittle) && !card.HasAbility(Ability.IceCube);
+            return fromCombat && this.Card.OnBoard && card.OpponentCard == this.Card.OpponentCard && !card.HasAbility(Ability.Brittle) && !card.HasAbility(Ability.IceCube);
         }
 
         public override IEnumerator OnOtherCardDie(PlayableCard card, CardSlot deathSlot, bool fromCombat, PlayableCard killer)
@@ -42,18 +43,25 @@ namespace Infiniscryption.P03KayceeRun.Cards
             yield return new WaitForSeconds(0.3f);
 
             CardInfo info = null;
-            if (card.Info.iceCubeParams != null)
+            if (card != null && card.Info != null && card.Info.iceCubeParams != null && card.Info.iceCubeParams.creatureWithin != null)
             {
-                info = CardLoader.GetCardByName(Card.Info.iceCubeParams.creatureWithin.name);
+                info = CardLoader.Clone(card.Info.iceCubeParams.creatureWithin);
             }
             else
             {
-                info = CardLoader.GetCardByName("RoboSkeleton");
-                CardModificationInfo mod = new();
-                mod.healthAdjustment = -1;
-                mod.attackAdjustment = -1;
-                mod.energyCostAdjustment = -2;
-                info.Mods.Add(mod);
+                if (P03AscensionSaveData.IsP03Run)
+                {
+                    info = CardLoader.GetCardByName("RoboSkeleton");
+                    CardModificationInfo mod = new();
+                    mod.healthAdjustment = -1;
+                    mod.attackAdjustment = -1;
+                    mod.energyCostAdjustment = -2;
+                    info.Mods.Add(mod);
+                }
+                else
+                {
+                    info = CardLoader.GetCardByName("Skeleton");
+                }
             }
             
             yield return BoardManager.Instance.CreateCardInSlot(info, deathSlot, 0.15f, true);

--- a/patchers/AscensionSaveData.cs
+++ b/patchers/AscensionSaveData.cs
@@ -326,7 +326,7 @@ namespace Infiniscryption.P03KayceeRun.Patchers
                 // __instance.deck.AddCard(CardLoader.GetCardByName(CustomCards.UNC_TOKEN));
                 // __instance.deck.AddCard(CardLoader.GetCardByName(CustomCards.UNC_TOKEN));
 
-                if (P03Plugin.Instance.DebugCode.ToLowerInvariant().Contains("rare"))
+                if (P03Plugin.Instance.DebugCode.ToLowerInvariant().Contains("rarestarter"))
                     __instance.deck.AddCard(CardLoader.GetCardByName(CustomCards.RARE_DRAFT_TOKEN));
 
                 // __instance.deck.AddCard(CardLoader.GetCardByName(CustomCards.RARE_DRAFT_TOKEN));

--- a/patchers/DialogueManagement.cs
+++ b/patchers/DialogueManagement.cs
@@ -223,7 +223,9 @@ namespace Infiniscryption.P03KayceeRun.Patchers
             {
                 string profanity = SeededRandom.Bool(P03AscensionSaveData.RandomSeed + offset++) ? "fucking" : "the fuck";
                 List<string> words = message.Split(' ').ToList();
-                words.Insert(SeededRandom.Range(0, words.Count, P03AscensionSaveData.RandomSeed + offset++), profanity);
+                int findex = SeededRandom.Range(0, words.Count, P03AscensionSaveData.RandomSeed + offset++);
+                if (words[findex].ToLowerInvariant() == "the" || words[findex].ToLowerInvariant() == "a")
+                    profanity = "fucking";
                 message = String.Join(" ", words);
             }
         }


### PR DESCRIPTION
This PR fixes a few things:

1) Quests that initialize with a status other than NotStarted are no longer added to the map twice.
2) Challenges can now be explicitly flagged to *not* appear in a Leshy run. The two neutral challenges in this mod are now flagged like this.
3) Necromancer has been fixed so that it will work properly in Act 1. This isn't a huge deal, but it's nice.
4) The "start with a rare token" debug code is updated to be 'rarestarter' instead of 'rare'
5) The profanity easter egg is a little smarter. Because why not.